### PR TITLE
Update cli.go

### DIFF
--- a/utils/cli.go
+++ b/utils/cli.go
@@ -109,7 +109,7 @@ func (fs *FlagSet) Get(flagName string) (interface{}, bool) {
 }
 
 func (fs *FlagSet) Usage() {
-	fmt.Println("Usage: Chipmunk file archiver [options]")
+	fmt.Println("Usage: SquirrelZip file archiver [options]")
 	fmt.Println("Options:")
 	for _, flag := range fs.flags {
 		fmt.Printf("  -%s: %s\n", flag.Name, flag.Usage)


### PR DESCRIPTION
This pull request includes a small change to the `Usage` method in the `utils/cli.go` file. The change updates the name of the file archiver in the usage message from "Chipmunk" to "SquirrelZip" to reflect the new branding.

* [`utils/cli.go`](diffhunk://#diff-34d007edfb43e3f4506f6ef8450ad11165ae44433b4ed86a5d4c022e47306395L112-R112): Updated the usage message to use "SquirrelZip" instead of "Chipmunk".